### PR TITLE
Handle missing secrets gracefully in async preview workflow

### DIFF
--- a/.github/workflows/pr-dev-preview.yml
+++ b/.github/workflows/pr-dev-preview.yml
@@ -45,6 +45,7 @@ jobs:
           pip install .
 
       - name: Validate required secrets
+        id: secrets
         env:
           ASYNC_BUILD_BASE_URL: ${{ secrets.ASYNC_BUILD_BASE_URL }}
           GH_DEPLOY_TOKEN: ${{ secrets.GH_DEPLOY_TOKEN }}
@@ -52,18 +53,27 @@ jobs:
           set -euo pipefail
           missing=0
           if [ -z "${ASYNC_BUILD_BASE_URL}" ]; then
-            echo "::error::ASYNC_BUILD_BASE_URL secret is not set"
+            echo "::warning::ASYNC_BUILD_BASE_URL secret is not set"
             missing=1
           fi
           if [ -z "${GH_DEPLOY_TOKEN}" ]; then
-            echo "::error::GH_DEPLOY_TOKEN secret is not set"
+            echo "::warning::GH_DEPLOY_TOKEN secret is not set"
             missing=1
           fi
+
           if [ "${missing}" -ne 0 ]; then
-            exit 1
+            {
+              echo "### Async preview prerequisites"
+              echo "- ⚠️ Async preview build skipped because required secrets are unavailable."
+              echo "- Configure the ASYNC_BUILD_BASE_URL and GH_DEPLOY_TOKEN secrets to enable preview provisioning."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            echo "missing=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "missing=false" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Prepare async build payload
+        if: steps.secrets.outputs.missing == 'false'
         id: payload
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -94,6 +104,7 @@ jobs:
           PY
 
       - name: Start async build
+        if: steps.secrets.outputs.missing == 'false'
         id: start
         env:
           PAYLOAD: ${{ steps.payload.outputs.json }}


### PR DESCRIPTION
## Summary
- update the pr-dev-preview workflow to detect missing async build secrets and skip the start/poll steps when they are absent
- add a job summary warning so maintainers know to configure ASYNC_BUILD_BASE_URL and GH_DEPLOY_TOKEN before previews are provisioned

## Testing
- pytest
- npm run smoke-test

------
https://chatgpt.com/codex/tasks/task_e_68e4abaa2244832f945646d369740f5e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Async preview workflow now warns and skips build steps when required secrets are absent, adding a job summary and gating downstream steps via outputs.
> 
> - **CI / GitHub Actions** (`.github/workflows/pr-dev-preview.yml`):
>   - **Secret validation**: Convert missing `ASYNC_BUILD_BASE_URL` and `GH_DEPLOY_TOKEN` from errors to warnings; add step `id: secrets` that sets `outputs.missing` and appends guidance to `GITHUB_STEP_SUMMARY`.
>   - **Conditional execution**: Gate `Prepare async build payload` and `Start async build` with `if: steps.secrets.outputs.missing == 'false'` to skip when prerequisites are not configured.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 593869fdae9071fcfbdca652496dd1eef0862076. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->